### PR TITLE
Feature/method overloading

### DIFF
--- a/Sample.Client.Test/InsightDataGenerator.cs
+++ b/Sample.Client.Test/InsightDataGenerator.cs
@@ -30,7 +30,7 @@ public class InsightDataGenerator
         }
         
         Console.WriteLine("***** generate slow endpoint insight *****");
-        for (int i = 0; i < 1; i++)
+        for (int i = 0; i < 2; i++)
         {
             HttpResponseMessage response = await _client.GetAsync($"{_url}/SampleInsights/SlowEndpoint?extraLatency=5000");
             Console.WriteLine(response.StatusCode);
@@ -60,6 +60,25 @@ public class InsightDataGenerator
             Console.WriteLine(response.StatusCode);
         }
         
+        Console.WriteLine("***** generate endpoints with method overloading A1 *****");
+        for (int i = 0; i < 5; i++)
+        {
+            HttpResponseMessage response = await _client.GetAsync($"{_url}/SampleInsights/OverloadingA1?name=someName{i}");
+            Console.WriteLine(response.StatusCode);
+        }
+        Console.WriteLine("***** generate endpoints with method overloading A2 *****");
+        for (int i = 0; i < 9; i++)
+        {
+            HttpResponseMessage response = await _client.GetAsync($"{_url}/SampleInsights/OverloadingA2?name=someName{i}&ids={i + 1}&ids={i + 102}");
+            Console.WriteLine(response.StatusCode);
+        }
+        Console.WriteLine("***** generate endpoints with method overloading A3 *****");
+        for (int i = 0; i < 3; i++)
+        {
+            HttpResponseMessage response = await _client.GetAsync($"{_url}/SampleInsights/OverloadingA3?name=someName{i}&description=someDesc{i}&longId={i + 1000}");
+            Console.WriteLine(response.StatusCode);
+        }
+
         Console.WriteLine("***** generate high usage insight *****");
         for (int i = 0; i < 400; i++)
         {

--- a/Sample.Client.Test/InsightDataGenerator.cs
+++ b/Sample.Client.Test/InsightDataGenerator.cs
@@ -17,7 +17,7 @@ public class InsightDataGenerator
         Console.WriteLine("***** START GenerateInsightData *****");
 
         Console.WriteLine("***** generate errors source *****");
-        for (int i = 0; i < 5; i++)
+        for (int i = 0; i < 10; i++)
         {
             HttpResponseMessage response = await _client.GetAsync($"{_url}/SampleInsights/ErrorSource");
             Console.WriteLine(response.StatusCode);

--- a/Sample.MoneyTransfer.Api/Controllers/SampleInsights.cs
+++ b/Sample.MoneyTransfer.Api/Controllers/SampleInsights.cs
@@ -14,7 +14,30 @@ class SampleInsightsService
     {
         throw new ConnectionAbortedException("aborting connection");
     } 
+    
+    // method DoSomething has Overloading implementations
     public void DoSomething()
+    {
+        Connect();
+    }
+    public void DoSomething(int int1)
+    {
+        Connect();
+    }
+    public void DoSomething(string str1)
+    {
+        Connect();
+    }
+    public void DoSomething(string str1, out bool bool1, IList<string> list1)
+    {
+        bool1 = true;
+        Connect();
+    }
+    public void DoSomething(ref long[] longsArr1, IEnumerable<string> enumerable1)
+    {
+        Connect();
+    }
+    public void DoSomething(IDictionary<string, string> dict1, int[] intsArr1)
     {
         Connect();
     }
@@ -111,16 +134,38 @@ public class SampleInsightsController  : ControllerBase
     {
         using var activity = Activity.StartActivity("ErrorSource");
         await Task.Delay(TimeSpan.FromMilliseconds(1));
-        if (Random.Next(1, 10) % 2 == 0)
+
+        var randVal = Random.Next(1, 9);
+        switch (randVal)
         {
-            _service.DoSomething();
-        }
-        else
-        {
-             _service.DoSomethingElse();
+            case 1:
+                _service.DoSomethingElse();
+                break;
+            case 2:
+                _service.DoSomething();
+                break;
+            case 3:
+                _service.DoSomething(3);
+                break;
+            case 4:
+                _service.DoSomething("lets go");
+                break;
+            case 5:
+                _service.DoSomething("yes", out bool bool1, new List<string>());
+                break;
+            case 6:
+                var longsArr = new long[] { };
+                _service.DoSomething(ref longsArr, new string[] { });
+                break;
+            case 7:
+                _service.DoSomething(new Dictionary<string, string>(), new int[] { });
+                break;
+            default:
+                _service.DoSomething();
+                break;
         }
     }
-    
+
     [HttpGet]
     [Route("Error")]
     public async Task Error()

--- a/Sample.MoneyTransfer.Api/Controllers/SampleInsights.cs
+++ b/Sample.MoneyTransfer.Api/Controllers/SampleInsights.cs
@@ -10,9 +10,14 @@ class SampleInsightsService
 {
     private static readonly ActivitySource Activity = new(nameof(SampleInsightsService));
 
+    private void Connect(string connectionName)
+    {
+        throw new ConnectionAbortedException($"aborting connection named {connectionName}");
+    }
+
     private void Connect()
     {
-        throw new ConnectionAbortedException("aborting connection");
+        Connect("basic");
     }
 
     // method DoSomething has Overloading implementations
@@ -23,23 +28,24 @@ class SampleInsightsService
 
     public void DoSomething(int int1)
     {
-        Connect();
+        Connect($"basic{int1}");
     }
 
     public void DoSomething(string str1)
     {
-        Connect();
+        Connect(str1);
     }
 
     public void DoSomething(string str1, out bool bool1, IList<string> list1)
     {
         bool1 = true;
-        Connect();
+        Connect(str1);
     }
 
     public void DoSomething(ref long[] longsArr1, IEnumerable<string> enumerable1, Func<int, string> func1)
     {
-        Connect();
+        var str = func1.Invoke(7);
+        Connect(str);
     }
 
     public void DoSomething(IDictionary<string, string> dict1, double[][][] doublesJaggedArr1)
@@ -54,12 +60,13 @@ class SampleInsightsService
 
     public void DoSomething(Func<int, int, string> func1, float[][,,,][][,,] floatsMixJaggedAndMultidimensionalArr1)
     {
-        Connect();
+        var str = func1.Invoke(7, 8);
+        Connect(str);
     }
 
     public void DoSomethingElse()
     {
-        Connect();
+        Connect("else");
     }
 
     public void ThrowArgumentException()

--- a/Sample.MoneyTransfer.Api/Controllers/SampleInsights.cs
+++ b/Sample.MoneyTransfer.Api/Controllers/SampleInsights.cs
@@ -77,7 +77,7 @@ class SampleInsightsService
 public class SampleInsightsController  : ControllerBase
 {
     private static readonly ActivitySource Activity = new(nameof(SampleInsightsController));
-    private static readonly Random Random = new();
+    private static readonly Random Random = new (Math.Abs((int)DateTime.Now.Ticks));
     private readonly SampleInsightsService _service;
     public SampleInsightsController()
     {

--- a/Sample.MoneyTransfer.Api/Controllers/SampleInsights.cs
+++ b/Sample.MoneyTransfer.Api/Controllers/SampleInsights.cs
@@ -37,12 +37,22 @@ class SampleInsightsService
         Connect();
     }
 
-    public void DoSomething(ref long[] longsArr1, IEnumerable<string> enumerable1)
+    public void DoSomething(ref long[] longsArr1, IEnumerable<string> enumerable1, Func<int, string> func1)
     {
         Connect();
     }
 
-    public void DoSomething(IDictionary<string, string> dict1, int[] intsArr1)
+    public void DoSomething(IDictionary<string, string> dict1, double[][][] doublesJaggedArr1)
+    {
+        Connect();
+    }
+
+    public void DoSomething(ICollection<object> objectsColl1, long[,,][,,,,][,][,,,] longsMultidimensionalArr1)
+    {
+        Connect();
+    }
+
+    public void DoSomething(Func<int, int, string> func1, float[][,,,][][,,] floatsMixJaggedAndMultidimensionalArr1)
     {
         Connect();
     }
@@ -139,7 +149,7 @@ public class SampleInsightsController : ControllerBase
         using var activity = Activity.StartActivity("ErrorSource");
         await Task.Delay(TimeSpan.FromMilliseconds(1));
 
-        var randVal = Random.Next(1, 9);
+        var randVal = Random.Next(1, 11);
         switch (randVal)
         {
             case 1:
@@ -159,10 +169,16 @@ public class SampleInsightsController : ControllerBase
                 break;
             case 6:
                 var longsArr = new long[] { };
-                _service.DoSomething(ref longsArr, new string[] { });
+                _service.DoSomething(ref longsArr, new string[] { }, x => $"val={x}");
                 break;
             case 7:
-                _service.DoSomething(new Dictionary<string, string>(), new int[] { });
+                _service.DoSomething(new Dictionary<string, string>(), new double[][][] { });
+                break;
+            case 8:
+                _service.DoSomething(new object[] { }, new long[,,][,,,,][,][,,,] { });
+                break;
+            case 9:
+                _service.DoSomething((x, y) => $"sum={x + y}", new float[][,,,][][,,] { });
                 break;
             default:
                 _service.DoSomething();

--- a/Sample.MoneyTransfer.Api/Controllers/SampleInsights.cs
+++ b/Sample.MoneyTransfer.Api/Controllers/SampleInsights.cs
@@ -13,34 +13,40 @@ class SampleInsightsService
     private void Connect()
     {
         throw new ConnectionAbortedException("aborting connection");
-    } 
-    
+    }
+
     // method DoSomething has Overloading implementations
     public void DoSomething()
     {
         Connect();
     }
+
     public void DoSomething(int int1)
     {
         Connect();
     }
+
     public void DoSomething(string str1)
     {
         Connect();
     }
+
     public void DoSomething(string str1, out bool bool1, IList<string> list1)
     {
         bool1 = true;
         Connect();
     }
+
     public void DoSomething(ref long[] longsArr1, IEnumerable<string> enumerable1)
     {
         Connect();
     }
+
     public void DoSomething(IDictionary<string, string> dict1, int[] intsArr1)
     {
         Connect();
     }
+
     public void DoSomethingElse()
     {
         Connect();
@@ -52,9 +58,8 @@ class SampleInsightsService
         {
             throw new ArgumentException("empty argument2");
         }
-
     }
-    
+
     public void HandledException()
     {
         using var activity = Activity.StartActivity("HandledException");
@@ -67,23 +72,23 @@ class SampleInsightsService
             {
                 activity.RecordException(ex);
             }
-            
         }
-
     }
 }
+
 [ApiController]
 [Route("[controller]")]
-public class SampleInsightsController  : ControllerBase
+public class SampleInsightsController : ControllerBase
 {
     private static readonly ActivitySource Activity = new(nameof(SampleInsightsController));
-    private static readonly Random Random = new (Math.Abs((int)DateTime.Now.Ticks));
+    private static readonly Random Random = new(Math.Abs((int)DateTime.Now.Ticks));
     private readonly SampleInsightsService _service;
+
     public SampleInsightsController()
     {
         _service = new SampleInsightsService();
     }
-    
+
     [HttpGet]
     [Route("Rethrow2")]
     public async Task Rethrow2()
@@ -94,12 +99,11 @@ public class SampleInsightsController  : ControllerBase
         {
             _service.ThrowArgumentException();
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
             activity.RecordException(ex);
             throw new ArgumentException("empty argument", ex);
         }
-        
     }
 
     [HttpGet]
@@ -112,12 +116,12 @@ public class SampleInsightsController  : ControllerBase
         {
             _service.ThrowArgumentException();
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
             throw new ArgumentException("empty argument", ex);
         }
     }
-    
+
     [HttpGet]
     [Route("Handled")]
     public async Task Handled()
@@ -127,7 +131,7 @@ public class SampleInsightsController  : ControllerBase
         _service.HandledException();
         throw new ArgumentException("empty argument");
     }
-    
+
     [HttpGet]
     [Route("ErrorSource")]
     public async Task ErrorSource()
@@ -179,14 +183,14 @@ public class SampleInsightsController  : ControllerBase
 
         throw new ValidationException("random validation error");
     }
-    
+
     [HttpGet]
     [Route("SlowEndpoint")]
-    public async Task SlowEndpoint([FromQuery]int extraLatency)
+    public async Task SlowEndpoint([FromQuery] int extraLatency)
     {
         await Task.Delay(extraLatency);
     }
-    
+
     [HttpGet]
     [Route("SpanBottleneck")]
     public async Task SpanBottleneck()
@@ -197,7 +201,7 @@ public class SampleInsightsController  : ControllerBase
         using var activity2 = Activity.StartActivity("SpanBottleneck 2");
         await Task.Delay(TimeSpan.FromMilliseconds(100));
     }
-    
+
     [HttpGet]
     [Route("OverloadingA1")]
     public async Task MethodOverloadingA([FromQuery] String name)
@@ -214,7 +218,8 @@ public class SampleInsightsController  : ControllerBase
 
     [HttpGet]
     [Route("OverloadingA3")]
-    public async Task MethodOverloadingA([FromQuery] String name, [FromQuery] String description, [FromQuery] long longId)
+    public async Task MethodOverloadingA([FromQuery] String name, [FromQuery] String description,
+        [FromQuery] long longId)
     {
         await Task.Delay(TimeSpan.FromMilliseconds(13));
     }
@@ -230,19 +235,18 @@ public class SampleInsightsController  : ControllerBase
     {
         await Task.Delay(TimeSpan.FromMilliseconds(5));
     }
-    
+
     [HttpGet]
     [Route("NormalUsage")]
     public async Task NormalUsage()
     {
         await Task.Delay(TimeSpan.FromMilliseconds(5));
     }
-    
+
     [HttpGet]
     [Route("HighUsage")]
     public async Task HighUsage()
     {
         await Task.Delay(TimeSpan.FromMilliseconds(5));
     }
-    
 }

--- a/Sample.MoneyTransfer.Api/Controllers/SampleInsights.cs
+++ b/Sample.MoneyTransfer.Api/Controllers/SampleInsights.cs
@@ -153,6 +153,27 @@ public class SampleInsightsController  : ControllerBase
         await Task.Delay(TimeSpan.FromMilliseconds(100));
     }
     
+    [HttpGet]
+    [Route("OverloadingA1")]
+    public async Task MethodOverloadingA([FromQuery] String name)
+    {
+        await Task.Delay(TimeSpan.FromMilliseconds(11));
+    }
+
+    [HttpGet]
+    [Route("OverloadingA2")]
+    public async Task MethodOverloadingA([FromQuery] String name, [FromQuery] int[] ids)
+    {
+        await Task.Delay(TimeSpan.FromMilliseconds(12));
+    }
+
+    [HttpGet]
+    [Route("OverloadingA3")]
+    public async Task MethodOverloadingA([FromQuery] String name, [FromQuery] String description, [FromQuery] long longId)
+    {
+        await Task.Delay(TimeSpan.FromMilliseconds(13));
+    }
+
     /*
      *1       1  
      * *3     10 mid

--- a/Sample.MoneyTransfer.Api/Sample.MoneyTransfer.API.csproj
+++ b/Sample.MoneyTransfer.Api/Sample.MoneyTransfer.API.csproj
@@ -11,14 +11,14 @@
     <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0175" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="6.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.4" />
-    <PackageReference Include="OpenTel.Instrumentation.Digma" Version="0.5.12" />
-    <PackageReference Include="OpenTelemetry" Version="1.2.0" />
+    <PackageReference Include="OpenTel.Instrumentation.Digma" Version="0.5.15" />
+    <PackageReference Include="OpenTelemetry" Version="1.3.0" />
     <PackageReference Include="OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta2" />
-    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.2.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.2.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.3.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.3.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.4" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.4" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.4" />
     <PackageReference Include="Scrutor" Version="4.2.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
   </ItemGroup>
@@ -32,4 +32,9 @@
     <Folder Include="Domain\Models\" />
     <Folder Include="Data\" />
   </ItemGroup>
+  <!--
+  <ItemGroup>
+    <ProjectReference Include="..\..\OpenTelemetry.Instrumentation.Digma\OpenTelemetry.Instrumentation.Digma.csproj" />
+  </ItemGroup>
+  -->
 </Project>


### PR DESCRIPTION
Now that Method Overloading PRs are checked in:
[dotnet instrumentation/PR 7](https://github.com/digma-ai/OpenTelemetry.Instrumentation.Digma/pull/7#) and [Backend Collector/PR 263](https://github.com/digma-ai/digma-collector-backend/pull/263) 

-  using method overloading in few places:

1. HTTP Endpoints
2. internal service - use method named `DoSomething` with all kinds of types.

- upgrading:

1. OpenTelemetry to 1.3.0
2. Dotnet Instrumentation to 0.5.15 so it supports method overloading